### PR TITLE
Fixed quote() error on invalid symbol

### DIFF
--- a/src/YahooFinanceQuery.php
+++ b/src/YahooFinanceQuery.php
@@ -292,9 +292,12 @@ class YahooFinanceQuery
 
         // add unix timestamp and UTC time
         foreach ($data as &$dataSet) {
-            $time = $dataSet['LastTradeTime'];
-            $date = $dataSet['LastTradeDate'];
-            $timeString = $time.' '.$date;
+            $timeString = null;
+            if ("N/A" != $dataSet['LastTradeTime'] && "N/A" != $dataSet['LastTradeDate']) {
+                $time = $dataSet['LastTradeTime'];
+                $date = $dataSet['LastTradeDate'];
+                $timeString = $time.' '.$date;
+            }
 
             $yahooTimezone = new \DateTimeZone('America/New_York');
             $yahooDateTime = new \DateTime($timeString, $yahooTimezone);


### PR DESCRIPTION
quote() would trigger a fatal error when fetching an invalid symbol.
The problem lies in the assumption that timestamps will be null for invalid values
while in csv mode they default to "N/A".

This fixes issue #5
