### PR TITLE
make user agent an optional setting

### DIFF
--- a/src/YahooFinanceQuery.php
+++ b/src/YahooFinanceQuery.php
@@ -838,10 +838,13 @@ class YahooFinanceQuery
         $response = array(
             'query' => $url,
             );
+            
+        $userAgent = @($this->config['userAgent'] ?: $_SERVER["HTTP_USER_AGENT"] ?: null);
+            
         //curl request
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER,true);
-        curl_setopt($ch, CURLOPT_USERAGENT, $_SERVER["HTTP_USER_AGENT"]);
+        curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);
         $response['result'] = curl_exec($ch);


### PR DESCRIPTION
When running in CLI $_SERVER["HTTP_USER_AGENT"] will be empty which triggers an Undefined index notice.
This change suppresses that notice and provides a means to set a user agent string.
